### PR TITLE
[check thread status][C++]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Title format: [check thread status][C++] -->
+<!-- Summary: What this snippet is about -->
+<!-- Compilation: how to compile and run; what's the expected output -->
+<!-- Language: highlight of language usage -->
+<!-- Implementation Notice:  what is tricky place to implement -->
+<!-- To Learn: what can be further explored (e.g., better alternatives, tradeoffs) -->
+<!-- Questions: What questions need further investigation -->
+
+## Summary
+
+## Compilation
+
+## Language
+
+## Implementation Notice
+
+## To Learn
+
+## Questions

--- a/c++/check_thread_status.cc
+++ b/c++/check_thread_status.cc
@@ -1,0 +1,37 @@
+#include <future>
+#include <thread>
+#include <chrono>
+#include <iostream>
+
+// This program offers an example of checking thread status
+//
+// Compile: clang++ -std=c++14 -stdlib=libc++ check_thread_status.cc
+
+int main() {
+  using namespace std::chrono_literals;
+  /* Run some task on new thread. The launch policy std::launch::async
+     makes sure that the task is run asynchronously on a new thread. */
+  auto future = std::async(std::launch::async,
+                           [] {
+                             std::this_thread::sleep_for(3s);
+                             return 8;
+  });
+
+  std::future_status status;
+  do
+  {
+    // Use wait_for() with zero milliseconds to check thread status.    
+    status = future.wait_for(0ms);
+
+    // Print status.
+    if (status == std::future_status::ready) {
+        std::cout << "Thread finished" << std::endl;
+    } else {
+        std::cout << "Thread still running" << std::endl;
+    }
+  } while (status != std::future_status::ready);
+
+  auto result = future.get(); // Get result.
+
+  std::cout << "result: " << result << std::endl;
+}


### PR DESCRIPTION
<!-- Title format: [check thread status][C++] -->
<!-- Summary: What this snippet is about -->
<!-- Compilation: how to compile and run; what's the expected output -->
<!-- Language: highlight of language usage -->
<!-- Implementation Notice:  what is tricky place to implement -->
<!-- To Learn: what can be further explored (e.g., better alternatives, tradeoffs) -->
<!-- Questions: What questions need further investigation -->

## Summary

The code use of C++11 `std::async` and `std::future` for running a task, then utilize the `wait_for` function of `std::future` to check if the thread is still running.

[ref](https://stackoverflow.com/questions/9094422/how-to-check-if-a-stdthread-is-still-running)

## Compilation

```
clang++ -std=c++14 -stdlib=libc++ check_thread_status.cc
```

Note that this code has to be compiled with `c++14` otherwise, you might hit similar error like [here](https://stackoverflow.com/questions/32263289/libstdc-doesnt-recognise-standard-library-literals).

```
$./a.out
<-- snip -->
Thread still running
Thread still running
Thread still running
Thread still running
Thread still running
Thread still running
Thread still running
Thread still running
Thread still running
Thread finished
result: 8
```

## Language

## Implementation Notice

## To Do

Reference linked above offers more way of checking thread status without using `std::async` to launch task (i.e., use `std::thread`)

## To Learn

More thorough study on `std::async` and `std::future`.

## Questions