### PR TITLE
[wait for all threads][C++]

### DIFF
--- a/c++/wait_for_all_threads.cc
+++ b/c++/wait_for_all_threads.cc
@@ -1,0 +1,20 @@
+#include<thread>
+#include<iostream>
+#include<vector>
+
+using namespace std;
+
+void message(int i) {
+  cout << "thread " << i << endl << std::flush;
+}
+
+int main() {
+  int NUM_THREADS = 5;
+  vector<thread> threads;
+  for(int i = 0; i < NUM_THREADS; ++i) {
+    threads.emplace_back(thread(message, i));
+  }
+  for(auto&& th: threads) {
+    th.join();
+  }
+}


### PR DESCRIPTION
<!-- Title format: [check thread status][C++] -->
<!-- Summary: What this snippet is about -->
<!-- Compilation: how to compile and run; what's the expected output -->
<!-- Language: highlight of language usage -->
<!-- Implementation Notice:  what is tricky place to implement -->
<!-- To Learn: what can be further explored (e.g., better alternatives, tradeoffs) -->
<!-- Questions: What questions need further investigation -->

## Summary

A commonly-seen pattern on how to spawn threads in batch and wait for all of them [ref](https://stackoverflow.com/questions/30297465/wait-for-all-threads-in-c)

## Compilation

```
clang++ -std=c++11 -stdlib=libc++ wait_for_all_threads.cc
```

```
$ ./a.out
thread thread thread thread thread 12340


```

## Language

## Implementation Notice

## To Learn

## Questions
